### PR TITLE
Truncate file

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ module.exports = (async (file, {readStart, writeStart} = {}) => {
                     }
 
                     writeIndex += currentIndex;
+					
                     callback();
                 } catch(e) {
                     log(e);
@@ -95,14 +96,18 @@ module.exports = (async (file, {readStart, writeStart} = {}) => {
         },
         flush(callback) {
             _writePromise
-                .then(() => { 
-					fs.truncate(fd, writeIndex);
-					close(fd);
-				})
+                .then(() => close(fd))
                 .then(callback);
         }
     });
 
+	
+	//Truncate the file up to where the write ends, otherwise
+	//some of the original content will remain in place
+	writeStream.on('finish', () => {
+		if( writeIndex > 0) fs.ftruncateSync(fd, writeIndex);
+	})
+	
     return {
         fd,
         readStream,

--- a/index.js
+++ b/index.js
@@ -95,7 +95,10 @@ module.exports = (async (file, {readStart, writeStart} = {}) => {
         },
         flush(callback) {
             _writePromise
-                .then(() => close(fd))
+                .then(() => { 
+					fs.truncate(fd, writeIndex);
+					close(fd);
+				})
                 .then(callback);
         }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "read-write-stream",
+  "name": "rw-stream",
   "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -761,9 +761,10 @@
       "dev": true
     },
     "papaparse": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-4.6.0.tgz",
-      "integrity": "sha512-ylm8pmgyz9rkS3Ng/ru5tHUF3JxWwKYP0aZZWZ8eCGdSxoqgYiDUXLNQei73mUJOjHw8QNu5ZNCsLoDpkMA6sg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.0.0.tgz",
+      "integrity": "sha512-gCqNseOMB5RInYXR051oWfCIZZI9ldhijkeMj0kNYLpE/hSRLHaW8ctoK4h3IuS1v8l+PovsV96LjXtgmzHRxA==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -851,9 +852,10 @@
       }
     },
     "rereadable-stream": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.1.3.tgz",
-      "integrity": "sha512-BTueUdF945nPQcwNezo3vemGWS0LqsivHqBpTucgwnJk2NkIseMb+NKN2QhiBNmVUxatw6mtw3EZixQ0IWBlQQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.2.0.tgz",
+      "integrity": "sha512-Bsd7Bfumun6VEYoiyY/Oua5VKKwhGg/oyZXk2Tu02UTPBzpA6tWK0r9chPYA9bmc1sOxuNWp8+G2ASUFdEPt9w==",
+      "dev": true
     },
     "resolve": {
       "version": "1.8.1",
@@ -914,19 +916,21 @@
       "dev": true
     },
     "scramjet": {
-      "version": "4.18.12",
-      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.18.12.tgz",
-      "integrity": "sha512-ASe1MKcxEwW/JXLxIl7qcR0HNFM+3OgDMtcIPAdZUlyHx0jdSd5X5y6kQwD3rO41nNLnGOlBTC20xVALodHpqA==",
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.25.0.tgz",
+      "integrity": "sha512-UTeQQJjlJqkKOJvytPd1vLkS8Dq7k/6UUs9PYCCeB+vH+ZLyAWYtVw1e6HDmXLojXZpEeqNQdCOoXlw4VM3wyg==",
+      "dev": true,
       "requires": {
-        "papaparse": "^4.6.0",
-        "rereadable-stream": "^1.1.3",
-        "scramjet-core": "^4.16.13"
+        "papaparse": "^5.0.0",
+        "rereadable-stream": "^1.2.0",
+        "scramjet-core": "^4.22.2"
       }
     },
     "scramjet-core": {
-      "version": "4.16.13",
-      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.16.13.tgz",
-      "integrity": "sha512-jEtVVJh0cnhcADx38SKs3io3Pl+1EOrcjea1e1W0zLE31YjtC1Cya6/5kh8+1hoMfehxxFPdt+zwmWaLrvxBWA=="
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.22.2.tgz",
+      "integrity": "sha512-AaRdlBpE1QKgniqmdasu9tN3mSKb0gPoMJbTDTlZrcjMI44Twrvbf585qL2ud+Tucf9oXXSiNZQQMdmBXqvUxw==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.1",


### PR DESCRIPTION
Truncate file to handle cases where the write index ends up behind the read index. This occurs in cases where the content being written is less than what is being read. As a consequence, you end up with extra unwanted data from the original file.